### PR TITLE
Remove this.loadingDate from "componentDidMount" to "loadOderList" function

### DIFF
--- a/src/pages/order/index.jsx
+++ b/src/pages/order/index.jsx
@@ -40,14 +40,19 @@ class OrderList extends Component {
       (res) => {
         this.setState(res)
       },
-      (errMsg) => {
-        this.setState({
-          list: []
-        })
-        if (errMsg === '订单不存在') {
-          errMsg = 'Order does not exist.'
+      (err) => {
+        if (err.isCanceled) {
+          console.log('promise canceled')
+          return;
+        } else {
+          this.setState({
+            list: []
+          })
+          if (err === '订单不存在') {
+            err = 'Order does not exist.'
+          }
+          _util.errorTips(err)
         }
-        _util.errorTips(errMsg)
       })
   }
 

--- a/src/pages/order/index.jsx
+++ b/src/pages/order/index.jsx
@@ -6,6 +6,7 @@ import SearchBar from 'pages/order/search-bar.jsx'
 import TableList from 'util/table-list/index.jsx'
 import Pagination from 'util/pagination/index.jsx'
 import Util from 'util/util.jsx'
+import makeCancelbalePromise from '../../util/cancelablePromise'
 
 const _util = new Util()
 const _order = new Order()
@@ -18,14 +19,24 @@ class OrderList extends Component {
       list: [],
       loadType: 'list'  //list or search
     }
+    this.loadingData = null;
   }
 
   componentDidMount() {
+    this.loadingData = makeCancelbalePromise(
+      _order.getOrderList(this.state)
+    );
     this.loadOrderList()
   }
 
+  componentWillUnmount() {
+    if (this.loadingData) {
+      this.loadingData.cancel();
+    }
+  }
+
   loadOrderList() {
-    _order.getOrderList(this.state).then(
+    this.loadingData.promise.then(
       (res) => {
         this.setState(res)
       },

--- a/src/util/cancelablePromise.js
+++ b/src/util/cancelablePromise.js
@@ -1,0 +1,18 @@
+const makeCancablePromise = (promise) => {
+  let hasCanceled_ = false;
+
+  const wrappedPromise = new Promise((resolve, reject) => {
+    promise.then(
+      val => hasCanceled_ ? reject({isCanceled: true}) : resolve(val),
+      error => hasCanceled_ ? reject({isCanceled: true}) : reject(error)
+    );
+  });
+  return {
+    promise: wrappedPromise,
+    cancel() {
+      hasCanceled_ = true;
+    },
+  };
+};
+
+export default makeCancablePromise;


### PR DESCRIPTION
componentDidMount() {
    this.loadingDate = _util.makeCancelablePromise(
      _order.getOrderList(this.state)
    )
    this.loadOrderList()
  }

componentDidMount is executed only once. Thus, other loading requests cannot access this.loadingDate once the component is mounted. Below is the solution: 

loadOrderList() {
    this.loadingDate = _util.makeCancelablePromise(
      _order.getOrderList(this.state)
    )
    this.loadingDate.promise.then(
      (res) => {
        this.setState(res)
      },
      (err) => {
        if (err.isCanceled) {
          return
        } else {
          this.setState({
            list: []
          })
          if (err === '订单不存在') {
            err = 'Order does not exist.'
          }
          _util.errorTips(err)
        }
      }
    )
  }

